### PR TITLE
Fix fixtures so stdlib v3.2.0 is tracked.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,7 @@
 fixtures:
   repositories:
-    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "stdlib":
+      repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+      ref: "3.2.0"
   symlinks:
     "dnsclient": "#{source_dir}"


### PR DESCRIPTION
Without this patch, spec tests will check out the master branch of
puppetlabs/stdlib even though the code is written for a specific tag
(v3.2.0), which can cause errors.
