### PR TITLE
Use non-strict stdlib dependency ?

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,4 +7,4 @@ summary 'Manage resolver'
 description "Manage a DNS client's resolver"
 project_page 'https://github.com/ghoneycutt/puppet-module-dnsclient/'
 
-dependency 'puppetlabs/stdlib',  '3.2.x'
+dependency 'puppetlabs/stdlib', '>= 3.2.0'


### PR DESCRIPTION
Hi,
I have the same problem than https://github.com/ghoneycutt/puppet-module-dnsclient/issues/7
I can't install dnsclient module with librarian (puppet module install)
it's possible to put a non strict dependence?

Thanks in advance !
