### PR TITLE
add support for setting the lookup parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This module has been tested to work on the following systems with Puppet v3.x on
  * Solaris 10
  * Ubuntu 10.04 LTS (Lucid Lynx)
  * Ubuntu 12.04 LTS (Precise Pangolin)
+ * OpenBSD 5
 
 # Parameters #
 
@@ -54,6 +55,12 @@ Domain setting. See **search**.
 sortlist
 --------
 Array of sortlist addresses.
+
+- *Default*: none
+
+lookup
+------
+Array of lookup options in OpenBSD.
 
 - *Default*: none
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class dnsclient                 (
   $search                      = ['UNSET'],
   $domain                      = 'UNSET',
   $sortlist                    = ['UNSET'],
+  $lookup                      = ['UNSET'],
   $resolver_config_file        = '/etc/resolv.conf',
   $resolver_config_file_ensure = 'file',
   $resolver_config_file_owner  = 'root',
@@ -21,6 +22,15 @@ class dnsclient                 (
   # Validates domain
   if is_domain_name($domain) != true {
     fail("Domain name, ${domain}, is invalid.")
+  }
+
+  # Validate lookup value
+  if (is_array($lookup) != true) and ($::operatingsystem == 'OpenBSD') {
+    fail('the dnsclient::lookup parameter needs to be an array of strings.')
+  }
+
+  if ($lookup != ['UNSET']) and ($::operatingsystem != 'OpenBSD') {
+    fail("the dnsclient::lookup parameter is only supported on OpenBSD. Detected operatingsystem is ${::operatingsystem}.")
   }
 
   # Validates $resolver_config_file_ensure

--- a/metadata.json
+++ b/metadata.json
@@ -42,6 +42,14 @@
       ]
     },
     {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [
+        "5.4",
+        "5.6",
+        "5.7"
+      ]
+    },
+    {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "5",

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -31,3 +31,6 @@ nameserver <%= @nameservers %>
 nameserver <%= nameserver %>
 <% end -%>
 <% end -%>
+<% if @lookup[0] != 'UNSET' -%>
+lookup<% @lookup.each do |lookup| %> <%= lookup %><% end %>
+<% end -%>


### PR DESCRIPTION
For OpenBSD there is an additional option in resolv.conf[0] which allows
controlling where the resolver will lookup names from. This includes
disallowing checking the /etc/hosts file when `lookup file` isn't provided.

[0] http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/resolv.conf.5
