### PR TITLE
Do not set options when the options parameter is an empty array

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -98,6 +98,30 @@ nameserver 8.8.4.4
     }
   end
 
+  context 'with empty options' do
+    let :params do
+      { :options => [] }
+    end
+
+    it { should contain_class('dnsclient') }
+
+    it {
+      should contain_file('dnsclient_resolver_config_file').with({
+        'ensure' => 'file',
+        'path'   => '/etc/resolv.conf',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0644',
+      })
+      should contain_file('dnsclient_resolver_config_file').with_content(
+%{# This file is being maintained by Puppet.
+# DO NOT EDIT
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+})
+    }
+  end
+
   context 'with options set to a single value' do
     let :params do
       { :options => 'ndots:2' }

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -21,7 +21,9 @@ domain <%= @domain %>
 <% if @options.class == String -%>
 options <%= @options %>
 <% else -%>
+<% if ! @options.empty? -%>
 options<% @options.each do |option| %> <%= option %><% end %>
+<% end -%>
 <% end -%>
 <% end -%>
 <% if @nameservers.class == String -%>


### PR DESCRIPTION
Without this patch, setting options parameter to an empty array results in /etc/resolv.conf having options listed with nothing after it.
