### PR TITLE
Make it explicit that this module is compatible with Puppet 5

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/ghoneycutt/puppet-module-dnsclient/issues",
   "description": "Manage a DNS client's resolver",
   "requirements": [
-    {"name":"puppet","version_requirement":">= 3.0.0 < 5.0.0"}
+    {"name":"puppet","version_requirement":">= 3.0.0 < 6.0.0"}
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}


### PR DESCRIPTION
Without this change Kafo-based installers need to be forced to load this module
with --skip-puppet-version-check. Other software that parses version
requirements in metadata.json may have similar issues.