### PR TITLE
Declare Support for EL 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ for the exact matrix of supported Puppet and ruby versions.
  * EL 5
  * EL 6
  * EL 7
+ * EL 8
  * Debian 6
  * SLES 10
  * SLES 11

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
@@ -34,7 +35,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
@@ -42,7 +44,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
@@ -50,7 +53,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
We tested the current version against CentOS 8, it works just fine.