### PR TITLE
Remove EOL Puppet Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,26 +18,6 @@ script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4"
-  - rvm: 2.4.1
-    env: PUPPET_GEM_VERSION="~> 5"
   - rvm: 2.5.1
     env: PUPPET_GEM_VERSION="~> 6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
   include:
   - rvm: 2.5.1
     env: PUPPET_GEM_VERSION="~> 6"
+  - rvm: 2.7.3
+    env: PUPPET_GEM_VERSION="~> 7"
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -21,18 +21,7 @@ gem 'puppet-lint-undef_in_function-check', :require => false
 gem 'puppet-lint-unquoted_string-check', :require => false
 gem 'puppet-lint-variable_contains_upcase', :require => false
 
-gem 'rspec',     '~> 2.0', :require => false          if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'rake',      '~> 10.0', :require => false         if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'json',      '<= 1.8', :require => false          if RUBY_VERSION < '2.0.0'
-gem 'json_pure', '<= 2.0.1', :require => false        if RUBY_VERSION < '2.0.0'
-gem 'metadata-json-lint',     '0.0.11'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'metadata-json-lint',     '1.0.0'    if RUBY_VERSION >= '1.9' && RUBY_VERSION < '2.0'
-gem 'metadata-json-lint' if RUBY_VERSION >= '2.0'
+gem 'metadata-json-lint'
 
-gem 'puppetlabs_spec_helper', '2.0.2',    :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9'
-gem 'parallel_tests',         '<= 2.9.0', :require => false if RUBY_VERSION < '2.0.0'
-
-if puppetversion && puppetversion < '5.0'
-  gem 'semantic_puppet', :require => false
-end
+gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false
+gem 'parallel_tests',         '<= 2.9.0', :require => false

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ code with no modifications to the module itself as a guiding principle.
 # Compatibility #
 
 This module has been tested to work on the following systems with the
-latest Puppet v3, v3 with future parser, v4, v5 and v6.  See `.travis.yml`
-for the exact matrix of supported Puppet and ruby versions.
+latest Puppet v6.  See `.travis.yml` for the exact matrix of supported
+Puppet and ruby versions.
 
  * EL 5
  * EL 6

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ code with no modifications to the module itself as a guiding principle.
 # Compatibility #
 
 This module has been tested to work on the following systems with the
-latest Puppet v6.  See `.travis.yml` for the exact matrix of supported
-Puppet and ruby versions.
+latest Puppet v6 and v7.  See `.travis.yml` for the exact matrix of
+supported Puppet and ruby versions.
 
  * EL 5
  * EL 6

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/ghoneycutt/puppet-module-dnsclient/issues",
   "description": "Manage a DNS client's resolver",
   "requirements": [
-    {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
+    {"name":"puppet","version_requirement":">= 6.0.0 < 7.0.0"}
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/ghoneycutt/puppet-module-dnsclient/issues",
   "description": "Manage a DNS client's resolver",
   "requirements": [
-    {"name":"puppet","version_requirement":">= 6.0.0 < 7.0.0"}
+    {"name":"puppet","version_requirement":">= 6.0.0 < 8.0.0"}
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}


### PR DESCRIPTION
As the TravisCI Jobs all fail below a certain point, this cleans up the environment to only contain supported Puppet versions.