### PR TITLE
Add a limit of 3 nameservers

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,10 @@ class dnsclient (
     fail('search and domain are mutually exclusive and both have been defined.')
   }
 
+  # Only 3 nameservers are generally allowed by resolv.conf, so lets ensure that
+  # (While letting people do interesting hiera things to generate nameserver lists)
+  $nameservers_slice = $nameservers[0,3]
+
   file { 'dnsclient_resolver_config_file':
     ensure  => $resolver_config_file_ensure,
     content => template('dnsclient/resolv.conf.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,9 @@
 # @param nameservers
 #   Array of nameservers. The default use Google's public name servers.
 #
+# @param nameserver_limit
+#   Integer of the number of nameservers to allow in the resolv.conf
+#
 # @param options
 #   Array of options. Set to `[]` if no options line should be present.
 #
@@ -34,6 +37,7 @@
 #
 class dnsclient (
   Array[Stdlib::IP::Address] $nameservers = ['8.8.8.8', '8.8.4.4'],
+  Integer[0] $nameserver_limit = 0,
   Array $options = ['rotate', 'timeout:1'],
   Optional[Array[String[1]]] $search = undef,
   Optional[Stdlib::Fqdn] $domain = undef,
@@ -50,8 +54,12 @@ class dnsclient (
   }
 
   # Only 3 nameservers are generally allowed by resolv.conf, so lets ensure that
-  # (While letting people do interesting hiera things to generate nameserver lists)
-  $nameservers_slice = $nameservers[0,3]
+  # (While letting people do interesting things in hiera to generate nameserver lists)
+  # Also provide a way to override
+  $nameservers_slice = $nameserver_limit ? {
+    0       => $nameservers,
+    default => $nameservers[0,$nameserver_limit],
+  }
 
   file { 'dnsclient_resolver_config_file':
     ensure  => $resolver_config_file_ensure,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -50,9 +50,33 @@ describe 'dnsclient' do
     }
   end
 
-  context 'with parameter nameservers set with 4 nameservers' do
+  context 'with parameter nameservers set with 5 nameservers' do
     let :params do
       { nameservers: ['4.2.2.2', '4.2.2.1', '1.1.1.1', '8.8.8.8', '8.8.4.4'] }
+    end
+
+    content = <<-END.gsub(%r{^\s+\|}, '')
+      |# This file is being maintained by Puppet.
+      |# DO NOT EDIT
+      |options rotate timeout:1
+      |nameserver 4.2.2.2
+      |nameserver 4.2.2.1
+      |nameserver 1.1.1.1
+      |nameserver 8.8.8.8
+      |nameserver 8.8.4.4
+    END
+
+    it {
+      is_expected.to contain_file('dnsclient_resolver_config_file').with_content(content)
+    }
+  end
+
+  context 'with parameter nameservers set with 5 nameservers and a limit of 3' do
+    let :params do
+      {
+        nameservers: ['4.2.2.2', '4.2.2.1', '1.1.1.1', '8.8.8.8', '8.8.4.4'],
+        nameserver_limit: 3,
+      }
     end
 
     content = <<-END.gsub(%r{^\s+\|}, '')

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -50,6 +50,25 @@ describe 'dnsclient' do
     }
   end
 
+  context 'with parameter nameservers set with 4 nameservers' do
+    let :params do
+      { nameservers: ['4.2.2.2', '4.2.2.1', '1.1.1.1', '8.8.8.8', '8.8.4.4'] }
+    end
+
+    content = <<-END.gsub(%r{^\s+\|}, '')
+      |# This file is being maintained by Puppet.
+      |# DO NOT EDIT
+      |options rotate timeout:1
+      |nameserver 4.2.2.2
+      |nameserver 4.2.2.1
+      |nameserver 1.1.1.1
+    END
+
+    it {
+      is_expected.to contain_file('dnsclient_resolver_config_file').with_content(content)
+    }
+  end
+
   context 'with parameter nameservers set to a single nameserver as an array' do
     let :params do
       { nameservers: ['4.2.2.2'] }

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -12,6 +12,6 @@ domain <%= @domain %>
 <% if not @options.empty? -%>
 options<% @options.each do |option| %> <%= option %><% end %>
 <% end -%>
-<% @nameservers.each do |nameserver| -%>
+<% @nameservers_slice.each do |nameserver| -%>
 nameserver <%= nameserver %>
 <% end -%>


### PR DESCRIPTION
The resolv.conf man page specifies that the limit is 3, and while there's no instant breakage, a lot of applications (kubernetes especially) complains loudly about being above the limit.

This implements not by limiting the array itself, but by slicing the nameservers provided, which allows you to have hiera do a merge unique on the array to have primary and secondary dc nameserver pairs, while only ever having 3 in your resolv.conf.

Example hiera might be:
dc1 has ns1.dc1 and ns2.dc1,
dc2 has ns1.dc2 and ns2.dc2,
common has all 4 in it,
which with merge: unique will result in the local dc having the local ns first and then ns1 from the other dc.