### PR TITLE
Allow setting nameservers limit

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,11 @@
 # @param nameservers
 #   Array of nameservers. The default use Google's public name servers.
 #
+# @param nameserver_limit
+#   Integer of the number of nameservers to allow in the resolv.conf
+#   NOTE: If 'nameservers' is over this limit, only the first X nameservers will be used where X is set by this limit.
+#         The nameservers over the limit will be discarded.
+#
 # @param options
 #   Array of options. Set to `[]` if no options line should be present.
 #
@@ -34,6 +39,7 @@
 #
 class dnsclient (
   Array[Stdlib::IP::Address] $nameservers = ['8.8.8.8', '8.8.4.4'],
+  Optional[Integer[0]] $nameserver_limit = undef,
   Array $options = ['rotate', 'timeout:1'],
   Optional[Array[String[1]]] $search = undef,
   Optional[Stdlib::Fqdn] $domain = undef,
@@ -47,6 +53,15 @@ class dnsclient (
 
   if $search and $domain {
     fail('search and domain are mutually exclusive and both have been defined.')
+  }
+
+  # Only 3 nameservers are generally allowed by resolv.conf, so lets ensure that
+  # (While letting people do interesting things in hiera to generate nameserver lists)
+  # Also provide a way to override
+  if $nameserver_limit {
+    $nameservers_slice = $nameservers[0,$nameserver_limit]
+  } else {
+    $nameservers_slice = $nameservers
   }
 
   file { 'dnsclient_resolver_config_file':

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -50,6 +50,49 @@ describe 'dnsclient' do
     }
   end
 
+  context 'with parameter nameservers set with 5 nameservers' do
+    let :params do
+      { nameservers: ['4.2.2.2', '4.2.2.1', '1.1.1.1', '8.8.8.8', '8.8.4.4'] }
+    end
+
+    content = <<-END.gsub(%r{^\s+\|}, '')
+      |# This file is being maintained by Puppet.
+      |# DO NOT EDIT
+      |options rotate timeout:1
+      |nameserver 4.2.2.2
+      |nameserver 4.2.2.1
+      |nameserver 1.1.1.1
+      |nameserver 8.8.8.8
+      |nameserver 8.8.4.4
+    END
+
+    it {
+      is_expected.to contain_file('dnsclient_resolver_config_file').with_content(content)
+    }
+  end
+
+  context 'with parameter nameservers set with 5 nameservers and a limit of 3' do
+    let :params do
+      {
+        nameservers: ['4.2.2.2', '4.2.2.1', '1.1.1.1', '8.8.8.8', '8.8.4.4'],
+        nameserver_limit: 3,
+      }
+    end
+
+    content = <<-END.gsub(%r{^\s+\|}, '')
+      |# This file is being maintained by Puppet.
+      |# DO NOT EDIT
+      |options rotate timeout:1
+      |nameserver 4.2.2.2
+      |nameserver 4.2.2.1
+      |nameserver 1.1.1.1
+    END
+
+    it {
+      is_expected.to contain_file('dnsclient_resolver_config_file').with_content(content)
+    }
+  end
+
   context 'with parameter nameservers set to a single nameserver as an array' do
     let :params do
       { nameservers: ['4.2.2.2'] }

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -12,6 +12,6 @@ domain <%= @domain %>
 <% if not @options.empty? -%>
 options<% @options.each do |option| %> <%= option %><% end %>
 <% end -%>
-<% @nameservers.each do |nameserver| -%>
+<% @nameservers_slice.each do |nameserver| -%>
 nameserver <%= nameserver %>
 <% end -%>


### PR DESCRIPTION
The resolv.conf man page specifies that the limit is 3, and while there's no instant breakage, a lot of applications (kubernetes especially) complains loudly about being above the limit.

This implements not by limiting the array itself, but by slicing the nameservers provided, which allows you to have hiera do a merge unique on the array to have primary and secondary dc nameserver pairs, while only ever having 3 in your resolv.conf.

Example hiera might be:
dc1 has ns1.dc1 and ns2.dc1,
dc2 has ns1.dc2 and ns2.dc2,
common has all 4 in it,
which with merge: unique will result in the local dc having the local ns first and then ns1 from the other dc.

Replaces #43